### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@ hf3lint
 =======
 
 [![Build Status](https://travis-ci.org/areku/hf3lint.svg?branch=master)](https://travis-ci.org/areku/hf3lint)
-[![Downloads](https://pypip.in/download/hf3lint/badge.svg)](https://pypi.python.org/pypi/hf3lint/)
-[![Latest Version](https://pypip.in/version/hf3lint/badge.svg)](https://pypi.python.org/pypi/hf3lint/)
-[![Supported Python versions](https://pypip.in/py_versions/hf3lint/badge.svg)](https://pypi.python.org/pypi/hf3lint/)
-[![Development Status](https://pypip.in/status/hf3lint/badge.svg)](https://pypi.python.org/pypi/hf3lint/)
-[![Download format](https://pypip.in/format/hf3lint/badge.svg)](https://pypi.python.org/pypi/hf3lint/)
-[![License](https://pypip.in/license/hf3lint/badge.svg)](https://pypi.python.org/pypi/hf3lint/)
+[![Downloads](https://img.shields.io/pypi/dm/hf3lint.svg
+[![Latest Version](https://img.shields.io/pypi/v/hf3lint.svg
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/hf3lint.svg
+[![Development Status](https://img.shields.io/pypi/status/hf3lint.svg
+[![Download format](https://img.shields.io/pypi/format/hf3lint.svg
+[![License](https://img.shields.io/pypi/l/hf3lint.svg
 
     Author: Alexander Weigl <Alexander.Weigl@student.kit.edu>
     License: GPL v3

--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@ hf3lint
 =======
 
 [![Build Status](https://travis-ci.org/areku/hf3lint.svg?branch=master)](https://travis-ci.org/areku/hf3lint)
-[![Downloads](https://img.shields.io/pypi/dm/hf3lint.svg
-[![Latest Version](https://img.shields.io/pypi/v/hf3lint.svg
-[![Supported Python versions](https://img.shields.io/pypi/pyversions/hf3lint.svg
-[![Development Status](https://img.shields.io/pypi/status/hf3lint.svg
-[![Download format](https://img.shields.io/pypi/format/hf3lint.svg
-[![License](https://img.shields.io/pypi/l/hf3lint.svg
+[![Latest Version](https://img.shields.io/pypi/v/hf3lint.svg)](https://pypi.python.org/pypi/hf3lint/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/hf3lint.svg)](https://pypi.python.org/pypi/hf3lint/)
+[![Development Status](https://img.shields.io/pypi/status/hf3lint.svg)](https://pypi.python.org/pypi/hf3lint/)
+[![Download format](https://img.shields.io/pypi/format/hf3lint.svg)](https://pypi.python.org/pypi/hf3lint/)
+[![License](https://img.shields.io/pypi/l/hf3lint.svg)](https://pypi.python.org/pypi/hf3lint/)
 
     Author: Alexander Weigl <Alexander.Weigl@student.kit.edu>
     License: GPL v3


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20hf3lint))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `hf3lint`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.